### PR TITLE
fix(codegen-init): add correct pubspec dependency

### DIFF
--- a/mcp_server_dart/lib/src/cli/codegen_init_command.dart
+++ b/mcp_server_dart/lib/src/cli/codegen_init_command.dart
@@ -18,7 +18,7 @@ Future<int> runCodegenInit({
   if (runPubAdd) {
     final result = await Process.start(
       'flutter',
-      ['pub', 'add', 'flutter_mcp_toolkit'],
+      ['pub', 'add', 'mcp_toolkit'],
       workingDirectory: projectRoot,
       mode: ProcessStartMode.inheritStdio,
     );


### PR DESCRIPTION
This PR fixes the dependency added by the `flutter-mcp-toolkit codegen-init`

Previously, codegen-init executed:

```
flutter pub add flutter_mcp_toolkit
```

However, flutter_mcp_toolkit is not a valid/existing pub package, so the command could not add the correct dependency to the target Flutter project’s pubspec.yaml.

This PR changes it to:

```
flutter pub add mcp_toolkit
```

Changes

* Update codegen_init_command.dart
* Replace flutter_mcp_toolkit with mcp_toolkit in the flutter pub add command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected package dependency reference to ensure the correct package is added to projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Arenukvern/mcp_flutter/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->