### PR TITLE
fix(codegen-init): use published mcp_toolkit package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -fsSL https://raw.githubusercontent.com/Arenukvern/mcp_flutter/main/install
 
 # 2. Add the toolkit to your Flutter app
 cd my-flutter-app
-flutter-mcp-toolkit codegen-init   # adds flutter_mcp_toolkit + emits main.dart snippet
+flutter-mcp-toolkit codegen-init   # adds mcp_toolkit + emits main.dart snippet
 
 # 3. Install skills for your AI agent
 flutter-mcp-toolkit init claude-code   # or: cursor | codex | cline | agents-skills | all
@@ -126,7 +126,7 @@ This MCP server is verified by [MseeP.ai](https://mseep.ai).
    - Check the tool's logs for connection errors
 
 3. **Dynamic Tools Not Appearing**
-   - Ensure `flutter_mcp_toolkit` package is properly initialized in your Flutter app
+   - Ensure `mcp_toolkit` package is properly initialized in your Flutter app
    - Check that tools are registered using `MCPToolkitBinding.instance.addEntries()`
    - Use `fmt_list_client_tools_and_resources` to verify registration
    - Hot reload your Flutter app after adding new tools
@@ -138,7 +138,7 @@ The Flutter MCP Server is registered with Smithery's registry, making it discove
 ```
 ┌─────────────────┐     ┌───────────────────────┐     ┌─────────────────┐
 │                 │     │  Flutter App with     │     │                 │
-│  Flutter App    │<--->│  flutter_mcp_toolkit  │<--->│ flutter-mcp-    │
+│  Flutter App    │<--->│  mcp_toolkit          │<--->│ flutter-mcp-    │
 │  (Debug Mode)   │     │  (VM Svc. Extensions  │     │ toolkit-server  │
 │                 │     │  + Dynamic Tools)     │     │                 │
 └─────────────────┘     └───────────────────────┘     └─────────────────┘

--- a/docs/start_here/why_this_repo_matters.mdx
+++ b/docs/start_here/why_this_repo_matters.mdx
@@ -25,7 +25,7 @@ Generic MCP or Dart-only tooling can expose low-level VM data, but real Flutter 
 
 - A Dart MCP server (`flutter-mcp-toolkit-server`) focused on Flutter workflows.
 - A CLI (`flutter-mcp-toolkit`) for deterministic automation, snapshots, and CI.
-- `flutter_mcp_toolkit` package for in-app extensions.
+- `mcp_toolkit` package for in-app extensions.
 - Dynamic tool/resource registration from the running app.
 - Target-resolution and retry guidance for multi-app debug sessions.
 

--- a/mcp_server_dart/bin/flutter_mcp_toolkit.dart
+++ b/mcp_server_dart/bin/flutter_mcp_toolkit.dart
@@ -2102,7 +2102,7 @@ final _argParser = ArgParser(allowTrailingOptions: false)
       ..addFlag(
         'pub-add',
         defaultsTo: true,
-        help: 'Run "flutter pub add flutter_mcp_toolkit" first.',
+        help: 'Run "flutter pub add mcp_toolkit" first.',
       ),
   );
 
@@ -2328,7 +2328,7 @@ Examples:
   flutter-mcp-toolkit codegen-init
   flutter-mcp-toolkit codegen-init --no-pub-add
 
-Adds flutter_mcp_toolkit to a Flutter app and emits boilerplate for main.dart.
+Adds mcp_toolkit to a Flutter app and emits boilerplate for main.dart.
 ''';
 
 Future<int> _runInitSubcommand(final ArgResults command) async {

--- a/mcp_server_dart/lib/src/cli/codegen_snippets.dart
+++ b/mcp_server_dart/lib/src/cli/codegen_snippets.dart
@@ -4,7 +4,7 @@ class CodegenSnippets {
   static const String flutterMainInit = '''
 import 'dart:async';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_mcp_toolkit/flutter_mcp_toolkit.dart';
+import 'package:mcp_toolkit/mcp_toolkit.dart';
 
 void main() {
   runZonedGuarded(

--- a/mcp_server_dart/lib/src/skill_assets.g.dart
+++ b/mcp_server_dart/lib/src/skill_assets.g.dart
@@ -295,7 +295,7 @@ Mode auto-detects (MCP if registered, else CLI). Override with `--mode mcp|cli|a
 
 ### `codegen-init`
 
-From a Flutter project root, add `flutter_mcp_toolkit` as a dependency and emit
+From a Flutter project root, add `mcp_toolkit` as a dependency and emit
 the boilerplate snippet for `lib/main.dart`.
 
 ```bash

--- a/mcp_server_dart/test/cli/codegen_init_command_test.dart
+++ b/mcp_server_dart/test/cli/codegen_init_command_test.dart
@@ -2,6 +2,7 @@
 import 'dart:io';
 
 import 'package:flutter_mcp_toolkit_server/src/cli/codegen_init_command.dart';
+import 'package:flutter_mcp_toolkit_server/src/cli/codegen_snippets.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -29,6 +30,20 @@ dependencies:
       expect(exitCode, 0);
       // No new files in the project root other than pubspec.yaml.
       expect(File('${tmp.path}/lib/main.dart').existsSync(), isFalse);
+    });
+
+    test('snippet imports the published mcp_toolkit package', () {
+      // Regression guard: the package is published on pub.dev as `mcp_toolkit`.
+      // `flutter_mcp_toolkit` does not exist there, so importing it in the
+      // emitted boilerplate would break `flutter pub get` / compilation.
+      expect(
+        CodegenSnippets.flutterMainInit,
+        contains("import 'package:mcp_toolkit/mcp_toolkit.dart';"),
+      );
+      expect(
+        CodegenSnippets.flutterMainInit,
+        isNot(contains('package:flutter_mcp_toolkit/')),
+      );
     });
 
     test('refuses to run if pubspec.yaml is missing', () async {

--- a/plugin/skills/flutter-mcp-toolkit-setup/SKILL.md
+++ b/plugin/skills/flutter-mcp-toolkit-setup/SKILL.md
@@ -197,7 +197,7 @@ Mode auto-detects (MCP if registered, else CLI). Override with `--mode mcp|cli|a
 
 ### `codegen-init`
 
-From a Flutter project root, add `flutter_mcp_toolkit` as a dependency and emit
+From a Flutter project root, add `mcp_toolkit` as a dependency and emit
 the boilerplate snippet for `lib/main.dart`.
 
 ```bash


### PR DESCRIPTION
## Problem

`flutter-mcp-toolkit codegen-init` still fails for end users with:

```
Because <app> depends on flutter_mcp_toolkit any which doesn't exist
(could not find package flutter_mcp_toolkit at https://pub.dev), version solving failed.
flutter pub add failed (exit 65)
```

## Root cause

The in-app Flutter library is published on pub.dev as **`mcp_toolkit`** (v3.0.0). There is **no** package named `flutter_mcp_toolkit` on pub.dev (returns 404), and no pubspec in this repo's history was ever named exactly `flutter_mcp_toolkit`. The `codegen-init` feature still referenced that non-existent name in several user-facing places:

- the boilerplate snippet emitted for `lib/main.dart` imported `package:flutter_mcp_toolkit/flutter_mcp_toolkit.dart` — so even after `pub add` succeeds, pasting the snippet fails to compile;
- the `--pub-add` flag help text and the `codegen-init` usage text instructed users to add `flutter_mcp_toolkit`;
- the setup skill + README/docs described the in-app package as `flutter_mcp_toolkit`.

The `flutter pub add` invocation itself was already corrected to `mcp_toolkit` in #84; this PR fixes the remaining references that still pointed at the dead name. The bare app-side `flutter_mcp_toolkit` reference was wrong. The class the snippet uses (`MCPToolkitBinding`) is defined only in `mcp_toolkit`, confirming the correct import.

## Changes

- `mcp_server_dart/lib/src/cli/codegen_snippets.dart` — emitted snippet imports `package:mcp_toolkit/mcp_toolkit.dart`
- `mcp_server_dart/bin/flutter_mcp_toolkit.dart` — `--pub-add` help + `codegen-init` usage reference `mcp_toolkit`
- `plugin/skills/flutter-mcp-toolkit-setup/SKILL.md` + `mcp_server_dart/lib/src/skill_assets.g.dart` (kept in sync) — setup docs use `mcp_toolkit`
- `README.md` (quick-start comment, integration-architecture diagram, troubleshooting note) + `docs/start_here/why_this_repo_matters.mdx` — in-app package referred to as `mcp_toolkit`
- `mcp_server_dart/test/cli/codegen_init_command_test.dart` — regression test asserting the snippet imports `mcp_toolkit` and never `package:flutter_mcp_toolkit/`

## Testing

- Added a regression test on `CodegenSnippets.flutterMainInit`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and troubleshooting instructions across README and guides.
  * Revised code generation initialization steps and onboarding materials.

* **Tests**
  * Added regression test to verify generated boilerplate code imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->