### PR TITLE
Fix Flutter Toolkit Commands Failing With Unknown property "isolateId"

### DIFF
--- a/mcp_toolkit/lib/src/mcp_toolkit_extensions.dart
+++ b/mcp_toolkit/lib/src/mcp_toolkit_extensions.dart
@@ -77,7 +77,7 @@ mixin MCPToolkitExtensions on MCPToolkitBindingBase {
         registerServiceExtension(
           name: extensionName,
           callback: (final parameters) async {
-            final wireArgs = parameters.map(MapEntry<String, Object?>.new);
+            final wireArgs = _extractToolArguments(parameters);
             final registration = entry.toRegistration();
             final args = coerceArgumentsForSchema(
               registration.descriptor.inputSchema,
@@ -191,3 +191,11 @@ mixin MCPToolkitExtensions on MCPToolkitBindingBase {
     };
   }
 }
+
+// Flutter's VM service extension transport injects isolateId into callback
+// parameters. It routes the VM service call to the target isolate; it is not
+// an MCP tool argument. Strip it before schema coercion/validation because
+// tool schemas intentionally reject unknown properties.
+Map<String, Object?> _extractToolArguments(
+  final Map<String, String> parameters,
+) => Map<String, Object?>.from(parameters)..remove('isolateId');

--- a/mcp_toolkit/test/mcp_toolkit_bootstrap_test.dart
+++ b/mcp_toolkit/test/mcp_toolkit_bootstrap_test.dart
@@ -1,9 +1,52 @@
-// ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: invalid_use_of_protected_member, lines_longer_than_80_chars
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mcp_toolkit/mcp_toolkit.dart';
 
 void main() {
+  test(
+    'service extension callbacks do not treat isolateId as a tool argument',
+    () async {
+      final binding = _CapturingToolkitBinding()..initialize();
+      Map<String, String>? capturedRequest;
+
+      final tool = mcpToolkitTool(
+        namespace: 'app',
+        definition: MCPToolDefinition(
+          name: 'inspect_number',
+          description: 'Inspect a number',
+          inputSchema: ObjectSchema(
+            properties: {'x': IntegerSchema()},
+            required: ['x'],
+          ),
+        ),
+        handler: (final request) {
+          capturedRequest = request;
+          return MCPCallResult(message: 'inspected', parameters: {'ok': true});
+        },
+      );
+
+      binding.initializeServiceExtensions(
+        errorMonitor: _TestErrorMonitor(),
+        entries: {tool},
+      );
+
+      final callback = binding.callbacks['inspect_number'];
+      expect(callback, isNotNull);
+
+      final result = await callback!({
+        'isolateId': 'isolates/4805254787721395',
+        'x': '120',
+      });
+
+      expect(result['ok'], isTrue);
+      expect(capturedRequest, isNotNull);
+      expect(capturedRequest, isNot(contains('isolateId')));
+      expect(capturedRequest?['x'], '120');
+    },
+  );
+
   testWidgets(
     'bootstrapFlutter initializes toolkit, adds entries, and forwards zone errors',
     (final tester) async {
@@ -81,3 +124,18 @@ void main() {
     },
   );
 }
+
+final class _CapturingToolkitBinding extends MCPToolkitBindingBase
+    with MCPToolkitExtensions {
+  final callbacks = <String, ServiceExtensionCallback>{};
+
+  @override
+  void registerServiceExtension({
+    required final String name,
+    required final ServiceExtensionCallback callback,
+  }) {
+    callbacks[name] = callback;
+  }
+}
+
+final class _TestErrorMonitor with ErrorMonitor {}


### PR DESCRIPTION
# Fix Flutter Toolkit Commands Failing With `Unknown property "isolateId"`

## Summary

- Strip Flutter VM Service `isolateId` metadata before `mcp_toolkit` validates tool arguments.
- Add a regression test for service extension callbacks that receive VM-injected `isolateId`.
- Keep real tool arguments intact while preventing strict schemas from rejecting VM routing metadata.

Closes https://github.com/Arenukvern/mcp_flutter/issues/94

## Problem

Flutter VM Service injects `isolateId` into service extension callback parameters as routing metadata.

`mcp_toolkit` was passing the full callback parameter map into schema coercion and validation. Because toolkit schemas are strict, commands could fail with:

```text
AgentValidationException: Unknown property "isolateId"
```

This affected app-side toolkit commands such as:

- `get_view_details`
- `semantic_snapshot`
- `get_app_errors`

## Fix

Filter VM Service metadata before schema coercion and validation:

```dart
final wireArgs = _extractToolArguments(parameters);
```

`_extractToolArguments` removes `isolateId` while preserving actual tool arguments.

```
Map<String, Object?> _extractToolArguments(
  final Map<String, String> parameters,
) => Map<String, Object?>.from(parameters)..remove('isolateId');
```
## Validation

- `flutter test test/mcp_toolkit_bootstrap_test.dart`
- `flutter test`
- `flutter analyze`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where tool extensions could fail schema validation during execution due to internal service fields being included in tool arguments.

* **Tests**
  * Added comprehensive test coverage for tool extension service invocations to verify proper argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->