### PR TITLE
fix(mcp_toolkit): tap double-dispatch on desktop + expose isSelected in semantic snapshot

### DIFF
--- a/mcp_toolkit/lib/src/services/gesture_interaction_service.dart
+++ b/mcp_toolkit/lib/src/services/gesture_interaction_service.dart
@@ -65,14 +65,6 @@ mixin GestureInteractionService {
       if (owner != null) {
         owner.performAction(node.id, SemanticsAction.tap);
         await _waitFrame();
-        // Desktop: performAction alone often skips Material button callbacks.
-        if (!kIsWeb) {
-          final center = SemanticSnapshotService.resolveCenter(ref);
-          if (center != null) {
-            await _dispatchTap(center);
-            await _waitFrame();
-          }
-        }
         return <String, Object?>{
           'success': true,
           'ref': ref,

--- a/mcp_toolkit/lib/src/services/semantic_snapshot_service.dart
+++ b/mcp_toolkit/lib/src/services/semantic_snapshot_service.dart
@@ -368,6 +368,7 @@ mixin SemanticSnapshotService {
         if (data.hasFlag(SemanticsFlag.isFocused)) 'focused': true,
         if (data.hasFlag(SemanticsFlag.isChecked)) 'checked': true,
         if (data.hasFlag(SemanticsFlag.isToggled)) 'toggled': true,
+        if (data.hasFlag(SemanticsFlag.isSelected)) 'selected': true,
         'bounds': <String, Object?>{
           'left': globalRect.left.roundToDouble(),
           'top': globalRect.top.roundToDouble(),


### PR DESCRIPTION
## Problem

On desktop, `fmt_tap_widget` fires the target's `onTap` **twice** for any widget with properly wired semantics.

`GestureInteractionService.tapAtRef` dispatches `SemanticsAction.tap` via `SemanticsOwner.performAction`, and then — on non-web platforms — *additionally* synthesizes `PointerDown`/`PointerUp` at the widget centre (the code comments this as a workaround for Material callbacks being skipped). When the node's semantics are correctly wired (Material buttons via `InkWell`, or explicit `Semantics(button: true)` wrappers), **both** paths invoke the handler.

Observed on a macOS desktop app (Flutter 3.44.6) after adding proper `Semantics(button: true, label: ...)` markup to its navigation rail:

- a single `fmt_tap_widget` on a toggle-style nav item opened the section and immediately closed it (log shows `visible=true` followed by `visible=false` from one tap), leaving a blank workspace;
- the synthesized events arrive from a mouse device the framework never saw a `PointerAddedEvent` for, tripping the framework assertion in `MouseTracker._shouldMarkStateDirty` (`(event is PointerAddedEvent) == (lastEvent is PointerRemovedEvent)` is not true) and leaving hover state (tooltips) stuck on screen.

Ironically the bug only bites apps with *good* accessibility markup — exactly the apps where semantic taps work best.

## Fix

1. **`tapAtRef`**: when the node exposes `SemanticsAction.tap`, the semantic action is authoritative — no follow-up pointer synthesis. Pointer synthesis remains the fallback for refs without a semantic tap action (`long_press` already behaves this way).
2. **Semantic snapshot**: emit `selected: true` for nodes with `SemanticsFlag.isSelected`, alongside the existing `checked`/`toggled`/`focused` flags — without it an agent can't tell which nav item is active even when the app sets `Semantics(selected: true)`.

## Verification

Live-tested on a macOS desktop app instrumented with mcp_toolkit `4.0.0-dev.6`:

- before: one `fmt_tap_widget` on a rail item → double toggle (`visible=true` → `visible=false` in shell logs) + `MouseTracker` assertion + stuck tooltip overlay;
- after: single activation via `"via": "semantic_action"`, section opens and stays open (semantic snapshot grows 21 → 130 nodes), no assertion, no stuck hover; the selected rail item now reports `"selected": true` in `fmt_semantic_snapshot`.

Contributing towards v4 stabilization (#92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Semantic snapshots now report whether an element is selected.

- **Bug Fixes**
  - Improved semantic tap handling by preventing duplicate pointer events on supported platforms, reducing the risk of actions being triggered twice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->