### PR TITLE
feat(mcp_toolkit): pump frames manually while the host window is backgrounded

### DIFF
--- a/mcp_toolkit/lib/src/services/background_frame_pump.dart
+++ b/mcp_toolkit/lib/src/services/background_frame_pump.dart
@@ -8,25 +8,33 @@ import 'package:flutter/widgets.dart';
 /// snapshot or screenshot would show the pre-action screen.
 ///
 /// Two frames are pumped: the first starts any just-triggered time-based
-/// animations, the second — far in the future — completes them. Raw
-/// timestamps come from the wall clock, which is monotonic across calls and
-/// far above the engine's frame clock; [SchedulerBinding.resetEpoch]
+/// animations, the second — far in the future — completes them. A microtask
+/// yield between [SchedulerBinding.handleBeginFrame] and
+/// [SchedulerBinding.handleDrawFrame] preserves the engine's mid-frame
+/// microtask phase, so futures completed by transient callbacks run before
+/// paint. Raw timestamps come from the wall clock, which is monotonic across
+/// calls and far above the engine's frame clock; [SchedulerBinding.resetEpoch]
 /// afterwards keeps the adjusted timeline continuous, so vsync frames resume
 /// without a time jump when the window becomes visible again.
-void pumpFramesIfSuspended() {
+Future<void> pumpFramesIfSuspended() async {
   // Web tabs throttle rAF instead of reporting a hidden lifecycle; driving
   // the pipeline manually there is untested — keep this desktop/mobile only.
   if (kIsWeb) return;
   final binding = WidgetsBinding.instance;
   if (binding.framesEnabled) return;
   if (SchedulerBinding.instance.schedulerPhase != SchedulerPhase.idle) return;
+  // A microtask yield (not an event-loop timer: zero-duration timers
+  // deadlock under the FakeAsync test zone) flushes mid-frame microtasks.
+  Future<void> yieldMicrotasks() => Future<void>.microtask(() {});
   var raw = Duration(microseconds: DateTime.now().microsecondsSinceEpoch);
-  binding
-    ..handleBeginFrame(raw)
-    ..handleDrawFrame();
+  binding.handleBeginFrame(raw);
+  await yieldMicrotasks();
+  binding.handleDrawFrame();
   raw += const Duration(minutes: 10);
+  await yieldMicrotasks();
+  binding.handleBeginFrame(raw);
+  await yieldMicrotasks();
   binding
-    ..handleBeginFrame(raw)
     ..handleDrawFrame()
     ..resetEpoch();
 }

--- a/mcp_toolkit/lib/src/services/background_frame_pump.dart
+++ b/mcp_toolkit/lib/src/services/background_frame_pump.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+/// Manually drives the frame pipeline when the engine delivers no vsync — a
+/// backgrounded/occluded desktop window suspends frames, so dispatched
+/// actions would otherwise never reach build/layout/paint/semantics and every
+/// snapshot or screenshot would show the pre-action screen.
+///
+/// Two frames are pumped: the first starts any just-triggered time-based
+/// animations, the second — far in the future — completes them. Raw
+/// timestamps come from the wall clock, which is monotonic across calls and
+/// far above the engine's frame clock; [SchedulerBinding.resetEpoch]
+/// afterwards keeps the adjusted timeline continuous, so vsync frames resume
+/// without a time jump when the window becomes visible again.
+void pumpFramesIfSuspended() {
+  // Web tabs throttle rAF instead of reporting a hidden lifecycle; driving
+  // the pipeline manually there is untested — keep this desktop/mobile only.
+  if (kIsWeb) return;
+  final binding = WidgetsBinding.instance;
+  if (binding.framesEnabled) return;
+  if (SchedulerBinding.instance.schedulerPhase != SchedulerPhase.idle) return;
+  var raw = Duration(microseconds: DateTime.now().microsecondsSinceEpoch);
+  binding
+    ..handleBeginFrame(raw)
+    ..handleDrawFrame();
+  raw += const Duration(minutes: 10);
+  binding
+    ..handleBeginFrame(raw)
+    ..handleDrawFrame()
+    ..resetEpoch();
+}

--- a/mcp_toolkit/lib/src/services/gesture_interaction_service.dart
+++ b/mcp_toolkit/lib/src/services/gesture_interaction_service.dart
@@ -1066,7 +1066,7 @@ mixin GestureInteractionService {
   /// the engine delivers no vsync — the pipeline is then driven manually so
   /// the dispatch still lands in layout/paint/semantics.
   static Future<void> _waitFrame() async {
-    pumpFramesIfSuspended();
+    await pumpFramesIfSuspended();
     await Future<void>.delayed(const Duration(milliseconds: 16));
   }
 

--- a/mcp_toolkit/lib/src/services/gesture_interaction_service.dart
+++ b/mcp_toolkit/lib/src/services/gesture_interaction_service.dart
@@ -11,6 +11,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import 'background_frame_pump.dart';
 import 'semantic_snapshot_service.dart';
 
 /// A service that drives the running Flutter app using a two-tier strategy:
@@ -1061,9 +1062,13 @@ mixin GestureInteractionService {
   }
 
   /// Wait one vsync frame (~16 ms) so the framework can flush pointer / focus
-  /// work triggered by a preceding dispatch.
-  static Future<void> _waitFrame() =>
-      Future<void>.delayed(const Duration(milliseconds: 16));
+  /// work triggered by a preceding dispatch. When the window is backgrounded
+  /// the engine delivers no vsync — the pipeline is then driven manually so
+  /// the dispatch still lands in layout/paint/semantics.
+  static Future<void> _waitFrame() async {
+    pumpFramesIfSuspended();
+    await Future<void>.delayed(const Duration(milliseconds: 16));
+  }
 
   static Future<void> _waitSemanticScrollFrame() async {
     await _waitFrame();

--- a/mcp_toolkit/lib/src/services/screenshot_service.dart
+++ b/mcp_toolkit/lib/src/services/screenshot_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import '../utils/image_compressor.dart';
+import 'background_frame_pump.dart';
 
 /// Service for taking screenshots of the main app view using RenderView layers.
 mixin ScreenshotService {
@@ -63,6 +64,7 @@ mixin ScreenshotService {
       );
       // Schedule a frame to ensure the layer tree is built and painted.
       WidgetsBinding.instance.scheduleFrame();
+      pumpFramesIfSuspended();
       // Wait for the frame to likely complete.
       await Future.delayed(const Duration(milliseconds: 100));
     }

--- a/mcp_toolkit/lib/src/services/screenshot_service.dart
+++ b/mcp_toolkit/lib/src/services/screenshot_service.dart
@@ -64,7 +64,7 @@ mixin ScreenshotService {
       );
       // Schedule a frame to ensure the layer tree is built and painted.
       WidgetsBinding.instance.scheduleFrame();
-      pumpFramesIfSuspended();
+      await pumpFramesIfSuspended();
       // Wait for the frame to likely complete.
       await Future.delayed(const Duration(milliseconds: 100));
     }

--- a/mcp_toolkit/lib/src/services/semantic_snapshot_service.dart
+++ b/mcp_toolkit/lib/src/services/semantic_snapshot_service.dart
@@ -238,12 +238,12 @@ mixin SemanticSnapshotService {
         // Cold path only: give Flutter a frame to actually populate the tree.
         binding.scheduleFrame();
         final endOfFrame = binding.endOfFrame;
-        pumpFramesIfSuspended();
+        await pumpFramesIfSuspended();
         await endOfFrame;
       } else {
         // A backgrounded window pumps no frames on its own — flush any
         // pending state so the snapshot reflects the latest dispatches.
-        pumpFramesIfSuspended();
+        await pumpFramesIfSuspended();
       }
 
       return await _buildSnapshotBody(incrementId: incrementId);

--- a/mcp_toolkit/lib/src/services/semantic_snapshot_service.dart
+++ b/mcp_toolkit/lib/src/services/semantic_snapshot_service.dart
@@ -5,6 +5,8 @@ import 'dart:ui' as ui;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'background_frame_pump.dart';
+
 /// A service that walks the Flutter semantics tree and produces a compact,
 /// AI-friendly snapshot of interactive / meaningful elements.
 ///
@@ -235,7 +237,13 @@ mixin SemanticSnapshotService {
       if (isCold) {
         // Cold path only: give Flutter a frame to actually populate the tree.
         binding.scheduleFrame();
-        await binding.endOfFrame;
+        final endOfFrame = binding.endOfFrame;
+        pumpFramesIfSuspended();
+        await endOfFrame;
+      } else {
+        // A backgrounded window pumps no frames on its own — flush any
+        // pending state so the snapshot reflects the latest dispatches.
+        pumpFramesIfSuspended();
       }
 
       return await _buildSnapshotBody(incrementId: incrementId);

--- a/mcp_toolkit/test/background_frame_pump_test.dart
+++ b/mcp_toolkit/test/background_frame_pump_test.dart
@@ -1,16 +1,17 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mcp_toolkit/src/services/background_frame_pump.dart';
 
 void main() {
   testWidgets('drives build manually while frames are suspended',
-      (tester) async {
+      (final tester) async {
     var counter = 0;
     late StateSetter setCounter;
     await tester.pumpWidget(
       MaterialApp(
         home: StatefulBuilder(
-          builder: (context, setState) {
+          builder: (final context, final setState) {
             setCounter = setState;
             return Text('count: $counter');
           },
@@ -19,8 +20,8 @@ void main() {
     );
     expect(find.text('count: 0'), findsOneWidget);
 
-    final binding = tester.binding;
-    binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+    final binding = tester.binding
+      ..handleAppLifecycleStateChanged(AppLifecycleState.hidden);
     addTearDown(
       () => binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed),
     );
@@ -29,16 +30,18 @@ void main() {
     setCounter(() => counter = 1);
     // No tester.pump: with frames suspended the engine would never deliver
     // this frame — the pump has to drive the pipeline itself.
-    pumpFramesIfSuspended();
+    await pumpFramesIfSuspended();
 
     expect(find.text('count: 1'), findsOneWidget);
-  });
+    // The pump is a web no-op, so this expectation cannot hold there.
+  }, skip: kIsWeb);
 
-  testWidgets('is a no-op when frames are enabled', (tester) async {
+  testWidgets('is a no-op when frames are enabled',
+      (final tester) async {
     await tester.pumpWidget(const Text('idle', textDirection: TextDirection.ltr));
     expect(tester.binding.framesEnabled, isTrue);
 
-    pumpFramesIfSuspended();
+    await pumpFramesIfSuspended();
 
     await tester.pump();
     expect(find.text('idle'), findsOneWidget);

--- a/mcp_toolkit/test/background_frame_pump_test.dart
+++ b/mcp_toolkit/test/background_frame_pump_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mcp_toolkit/src/services/background_frame_pump.dart';
+
+void main() {
+  testWidgets('drives build manually while frames are suspended',
+      (tester) async {
+    var counter = 0;
+    late StateSetter setCounter;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: StatefulBuilder(
+          builder: (context, setState) {
+            setCounter = setState;
+            return Text('count: $counter');
+          },
+        ),
+      ),
+    );
+    expect(find.text('count: 0'), findsOneWidget);
+
+    final binding = tester.binding;
+    binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+    addTearDown(
+      () => binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed),
+    );
+    expect(binding.framesEnabled, isFalse);
+
+    setCounter(() => counter = 1);
+    // No tester.pump: with frames suspended the engine would never deliver
+    // this frame — the pump has to drive the pipeline itself.
+    pumpFramesIfSuspended();
+
+    expect(find.text('count: 1'), findsOneWidget);
+  });
+
+  testWidgets('is a no-op when frames are enabled', (tester) async {
+    await tester.pumpWidget(const Text('idle', textDirection: TextDirection.ltr));
+    expect(tester.binding.framesEnabled, isTrue);
+
+    pumpFramesIfSuspended();
+
+    await tester.pump();
+    expect(find.text('idle'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Problem

On desktop, an AI agent typically drives the app while its window sits in the background — and a backgrounded/occluded window receives no vsync. Semantic actions dispatched over the VM service still execute (state changes, routes push), but nothing renders until the window becomes visible again:

- `semantic_snapshot` / screenshots keep showing the **pre-action** screen;
- `endOfFrame` waits (cold snapshot path) hang;
- agents interpret the stale snapshot as a missed tap and re-tap, **double-firing** the action (e.g. stacking the same dialog twice);
- all deferred route/dialog animations replay in a burst when the user activates the window.

Repro (macOS): run any app with the toolkit, put the window fully behind another app, `tap_widget` something state-changing, take `semantic_snapshot` → the snapshot still shows the old screen although the action fired.

## Fix

`pumpFramesIfSuspended()` (new `background_frame_pump.dart`) drives the frame pipeline manually when `WidgetsBinding.framesEnabled` is false:

- two `handleBeginFrame`/`handleDrawFrame` pairs — the first starts any just-triggered time-based animations, the second (with a timestamp far ahead) completes them;
- raw timestamps come from the wall clock, which is monotonic across calls and always above the engine's frame clock (a merely *large constant* is not enough: on a long-lived app a too-small timestamp yields negative ticker elapsed time and animations stall);
- `resetEpoch()` afterwards keeps the adjusted timeline continuous, so resumed vsync frames don't jump backwards.

Hooked into the three places that previously relied on vsync arriving:

- `gesture_interaction_service._waitFrame` — after every dispatched gesture/semantic action;
- `semantic_snapshot_service` — cold path (unblocks the `endOfFrame` wait) and warm path (flushes pending dispatches before capturing);
- `screenshot_service` — the needs-paint pre-wait.

No-op on the web (`kIsWeb` guard — rAF-throttled tabs behave differently and are untested) and whenever frames are enabled, so foreground behavior is unchanged.

## Testing

- New `background_frame_pump_test.dart`: with lifecycle `hidden` (`framesEnabled == false`) a `setState` becomes visible to finders after `pumpFramesIfSuspended()` without any `tester.pump`; and the pump is a safe no-op when frames are enabled.
- Full `mcp_toolkit` suite: 77/77 green.
- Field-tested on macOS: with the window fully backgrounded, tap → snapshot now round-trips with fresh semantics (tab switches, dialogs opening/closing), no focus stealing required. Known cosmetic effect: when the user activates the window, in-flight animations may visibly jump once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UI updates, gesture responsiveness, screenshots, and semantic snapshots when the app is backgrounded or when frame delivery is suspended.
  - Ensured pending layout/paint/semantics work and time-based animations complete reliably without relying on normal refresh signals.

- **Tests**
  - Added widget tests covering rendering progress while frames are suspended and confirming no behavior change when frames are already active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->