### PR TITLE
fix(server): return capture_ui_snapshot images as ImageContent

### DIFF
--- a/packages/server_capability_core/lib/src/tools/inspection_tools.dart
+++ b/packages/server_capability_core/lib/src/tools/inspection_tools.dart
@@ -156,10 +156,12 @@ void registerInspectionTools(final CapabilityContext context) {
   // ---------------------------------------------------------------------------
   // capture_ui_snapshot
   // ---------------------------------------------------------------------------
-  // The "bundle" described in docs is JSON inside a single TextContent.
-  // Legacy resource_handler.dart captureUiSnapshot (lines 472-474) returns
-  //   CallToolResult(content: [TextContent(text: jsonEncode(result.data))]).
-  // No multi-content transform required — standard runCommand with no onSuccess.
+  // The bundle travels as JSON in a TextContent, but captured images are lifted
+  // out of `screenshots.images` into ImageContent blocks (same artifact contract
+  // as get_screenshots). Base64 inlined into the JSON counts against the client
+  // response budget as text, which overflows it for a single desktop frame.
+  // `imageSummaries` keeps the per-image ids/hashes, so the bundle stays
+  // self-describing with the payload removed.
   context.registerTool(
     ToolRegistration(
       name: 'capture_ui_snapshot',
@@ -188,6 +190,33 @@ void registerInspectionTools(final CapabilityContext context) {
             screenshotMode: parseScreenshotMode(args['screenshotMode']),
             permissionPolicy: parsePermissionPolicy(args['permissionPolicy']),
           ),
+          onSuccess: (final data) {
+            final bundle = _asMap(data);
+            final screenshots = _asMap(bundle['screenshots']);
+            final images = _stringList(screenshots['images']);
+            if (images.isEmpty) {
+              return AgentResult.success(
+                artifacts: [AgentArtifact.text(jsonEncode(bundle))],
+              );
+            }
+            return AgentResult.success(
+              artifacts: [
+                AgentArtifact.text(
+                  jsonEncode(<String, Object?>{
+                    ...bundle,
+                    'screenshots': <String, Object?>{
+                      ...screenshots,
+                      'images': const <String>[],
+                    },
+                  }),
+                ),
+                ...images.map(
+                  (final image) =>
+                      AgentArtifact.text(image, mimeType: 'image/png'),
+                ),
+              ],
+            );
+          },
         );
       },
     ),

--- a/packages/server_capability_core/test/tools/inspection_tools_test.dart
+++ b/packages/server_capability_core/test/tools/inspection_tools_test.dart
@@ -592,6 +592,73 @@ void main() {
     );
 
     test(
+      'capture_ui_snapshot onSuccess: images move to ImageContent blocks '
+      'and leave the bundle JSON',
+      () async {
+        final runner = FakeCommandRunner()
+          ..nextExecuteResult = CoreResult.success(
+            data: {
+              'message': 'Captured UI snapshot bundle.',
+              'screenshots': {
+                'images': ['base64dataA', 'base64dataB'],
+                'fileUrls': <String>[],
+                'captureMode': 'flutter_layer',
+              },
+              'imageSummaries': [
+                {'id': 'image_1', 'source': 'inline_base64'},
+                {'id': 'image_2', 'source': 'inline_base64'},
+              ],
+            },
+          );
+        final ctx = _registeredCtx(runner: runner);
+        final reg = ctx.registrationFor('capture_ui_snapshot')!;
+        final result = await reg.handler(const <String, Object?>{});
+        expect(result.ok, isTrue);
+        expect(result.artifacts, hasLength(3));
+
+        final bundle =
+            jsonDecode(result.artifacts.first.text!) as Map<String, Object?>;
+        final screenshots = bundle['screenshots']! as Map<String, Object?>;
+        expect(screenshots['images'], isEmpty);
+        expect(screenshots['captureMode'], 'flutter_layer');
+        expect(bundle['imageSummaries'], hasLength(2));
+
+        final images = result.artifacts
+            .where((final a) => a.mimeType == 'image/png')
+            .toList();
+        expect(images, hasLength(2));
+        expect(images[0].text, 'base64dataA');
+        expect(images[1].text, 'base64dataB');
+      },
+    );
+
+    test(
+      'capture_ui_snapshot onSuccess: fileUrls bundle stays a single '
+      'TextContent',
+      () async {
+        final runner = FakeCommandRunner()
+          ..nextExecuteResult = CoreResult.success(
+            data: {
+              'screenshots': {
+                'images': <String>[],
+                'fileUrls': ['file:///tmp/screen0.png'],
+              },
+            },
+          );
+        final ctx = _registeredCtx(runner: runner);
+        final reg = ctx.registrationFor('capture_ui_snapshot')!;
+        final result = await reg.handler(const <String, Object?>{});
+        expect(result.ok, isTrue);
+        expect(result.artifacts, hasLength(1));
+        expect(result.artifacts.single.mimeType, 'text/plain');
+        final bundle =
+            jsonDecode(result.artifacts.single.text!) as Map<String, Object?>;
+        final screenshots = bundle['screenshots']! as Map<String, Object?>;
+        expect(screenshots['fileUrls'], ['file:///tmp/screen0.png']);
+      },
+    );
+
+    test(
       'capture_ui_snapshot handler short-circuits on override failure',
       () async {
         final runner = FakeCommandRunner()


### PR DESCRIPTION
## Problem

`capture_ui_snapshot` is registered without an `onSuccess` transform ([`inspection_tools.dart`](https://github.com/Arenukvern/mcp_flutter/blob/main/packages/server_capability_core/lib/src/tools/inspection_tools.dart#L163)), so `runCommand` falls through to the default path and `agentResultToMcpResult` serialises the entire bundle into one `TextContent`. With `saveImagesToFiles` off (the default), `screenshots.images` holds inline base64, so a single 1512×882 desktop frame ships ~145 KB of base64 **as text**.

Clients that cap tool output reject the result outright, which makes the tool the docs promote as step 1 of the debugging workflow ("unified evidence") unusable over MCP unless the server is started with `--save-images`. Observed with Claude Code: `fmt_capture_ui_snapshot` fails with "result (145,873 characters) exceeds maximum allowed tokens", while `fmt_get_screenshots` against the same app and the same VM extension returns fine.

The CLI is unaffected — `fmtk exec` prints the `CoreResult` envelope and never reaches the capability tool layer — so the documented CLI recipes keep their current output.

## Change

Give `capture_ui_snapshot` the artifact contract `get_screenshots` already uses:

- captured frames become `ImageContent` blocks (`AgentArtifact.text(image, mimeType: 'image/png')`);
- the rest of the bundle is emitted as text JSON with `screenshots.images` emptied — `imageSummaries` still carries the per-image ids/hashes, so the JSON stays self-describing;
- the `fileUrls` branch is untouched: with `--save-images` there are no inline images and the bundle stays a single `TextContent`.

## Verification

- `dart test` in `packages/server_capability_core` — 241 tests pass, including two new cases (images lifted into `image/png` artifacts with the JSON stripped; `fileUrls` bundle still a single text block).
- End-to-end against a live Flutter macOS app through the rebuilt stdio server: `tools/call fmt_capture_ui_snapshot` now returns 2 content blocks — `text` 15,524 chars + `image` (`image/png`) — instead of one 145 KB text block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI snapshot results now provide bundle details separately from captured PNG images.
  * Multiple captured images are returned as individual image artifacts for easier viewing and processing.
  * Snapshot results without embedded images continue to be provided as JSON.

* **Bug Fixes**
  * Preserved complete snapshot metadata while removing embedded image data from the JSON payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->