### PR TITLE
fix(tool): detect repo root from a linked worktree in build_skill_assets

### DIFF
--- a/mcp_server_dart/tool/build_skill_assets.dart
+++ b/mcp_server_dart/tool/build_skill_assets.dart
@@ -132,7 +132,10 @@ _Parts _splitFrontmatter(final String content) {
 Directory _findRepoRoot() {
   var dir = Directory.current;
   while (dir.parent.path != dir.path) {
-    if (Directory('${dir.path}/.git').existsSync()) return dir;
+    // `.git` is a directory in a plain clone, and a file holding a `gitdir:`
+    // pointer in a linked worktree or a submodule checkout.
+    final marker = '${dir.path}/.git';
+    if (Directory(marker).existsSync() || File(marker).existsSync()) return dir;
     dir = dir.parent;
   }
   throw StateError('Not in a git repo');


### PR DESCRIPTION
## Problem

`_findRepoRoot()` in `mcp_server_dart/tool/build_skill_assets.dart` walks up from the current directory looking for a `.git` **directory**. In a linked worktree (`git worktree add`) — and in a submodule checkout — `.git` is a *file* holding a `gitdir:` pointer, so the walk runs past the repo root and the tool aborts:

```
Unhandled exception:
Bad state: Not in a git repo
#0      _findRepoRoot (.../mcp_server_dart/tool/build_skill_assets.dart:138:3)
#1      main (.../mcp_server_dart/tool/build_skill_assets.dart:30:20)
make: *** [sync-skills] Error 255
```

`sync-skills` is a prerequisite of `compile`, so `make compile` cannot run from a worktree at all. That is a normal setup when validating a PR branch side by side with a working checkout.

## Change

Accept both shapes of the marker — a `.git` directory or a `.git` file. Plain clones still match the directory check first, so their behaviour is unchanged.

## Verification

From a linked worktree, all previously failing paths now succeed and regenerate `skill_assets.g.dart` byte-identically to the committed file:

- `make sync-skills` in `mcp_server_dart/` — the exact command that failed above;
- `dart run mcp_server_dart/tool/build_skill_assets.dart` from the worktree root and from a nested package directory;
- `bash tool/contracts/check_skill_assets_drift.sh` → `skill_assets.g.dart in sync with plugin/`;
- `git status` after the runs shows no drift beyond the tool file itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository detection across standard checkouts, linked worktrees, and submodules.
  * Build asset discovery now works when Git metadata is represented by either a directory or a file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->