### PR TITLE
feat(gestures): platform-appropriate pointer kind for drag

### DIFF
--- a/mcp_server_dart/lib/src/shared_core/command_executor.dart
+++ b/mcp_server_dart/lib/src/shared_core/command_executor.dart
@@ -1088,7 +1088,7 @@ final class DefaultCoreCommandExecutor implements CoreCommandExecutor {
           'fromRef': command.fromRef,
           'toRef': command.toRef,
           if (command.snapshotId != null) 'snapshotId': command.snapshotId,
-          if (command.kind != null) 'kind': command.kind,
+          if (command.kind case final kind?) 'kind': kind.wireName,
         },
       );
       return CoreResult.success(data: _map(result.json));

--- a/mcp_server_dart/lib/src/shared_core/command_executor.dart
+++ b/mcp_server_dart/lib/src/shared_core/command_executor.dart
@@ -1088,6 +1088,7 @@ final class DefaultCoreCommandExecutor implements CoreCommandExecutor {
           'fromRef': command.fromRef,
           'toRef': command.toRef,
           if (command.snapshotId != null) 'snapshotId': command.snapshotId,
+          if (command.kind != null) 'kind': command.kind,
         },
       );
       return CoreResult.success(data: _map(result.json));

--- a/mcp_server_dart/lib/src/shared_core/commands/commands_catalog.dart
+++ b/mcp_server_dart/lib/src/shared_core/commands/commands_catalog.dart
@@ -801,7 +801,7 @@ final class CommandCatalog {
           fromRef: _stringArg(args, 'fromRef', fallback: ''),
           toRef: _stringArg(args, 'toRef', fallback: ''),
           snapshotId: _nullableIntArg(args, 'snapshotId', alias: 'snapshot-id'),
-          kind: _nullableStringArg(args, 'kind'),
+          kind: parseDragPointerKind(_nullableStringArg(args, 'kind')),
         ),
       ),
       CommandSpec(

--- a/mcp_server_dart/lib/src/shared_core/commands/commands_catalog.dart
+++ b/mcp_server_dart/lib/src/shared_core/commands/commands_catalog.dart
@@ -801,6 +801,7 @@ final class CommandCatalog {
           fromRef: _stringArg(args, 'fromRef', fallback: ''),
           toRef: _stringArg(args, 'toRef', fallback: ''),
           snapshotId: _nullableIntArg(args, 'snapshotId', alias: 'snapshot-id'),
+          kind: _nullableStringArg(args, 'kind'),
         ),
       ),
       CommandSpec(

--- a/mcp_toolkit/lib/src/services/gesture_interaction_service.dart
+++ b/mcp_toolkit/lib/src/services/gesture_interaction_service.dart
@@ -5,7 +5,8 @@
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -705,9 +706,16 @@ mixin GestureInteractionService {
   }
 
   /// Drag from the centre of [fromRef] to the centre of [toRef].
+  ///
+  /// [kind] selects the synthesized pointer device; when null, defaults to
+  /// [PointerDeviceKind.mouse] on desktop platforms and
+  /// [PointerDeviceKind.touch] elsewhere — the device a real user would
+  /// drag with there. See [_dispatchDrag] for how the kind decides the
+  /// gesture-arena outcome.
   static Future<Map<String, Object?>> drag({
     required final String fromRef,
     required final String toRef,
+    final PointerDeviceKind? kind,
   }) async {
     final from = SemanticSnapshotService.resolveCenter(fromRef);
     if (from == null) {
@@ -735,17 +743,28 @@ mixin GestureInteractionService {
             'mutate state directly via evaluate_dart_expression.',
       };
     }
-    await _dispatchDrag(from, to, steps: 12);
+    final effectiveKind = kind ?? _defaultDragKind();
+    await _dispatchDrag(from, to, steps: 12, kind: effectiveKind);
     return <String, Object?>{
       'success': true,
       'via': 'pointer_events',
       'action': 'drag',
+      'kind': effectiveKind.name,
       'fromRef': fromRef,
       'toRef': toRef,
       'from': _offsetToMap(from),
       'to': _offsetToMap(to),
     };
   }
+
+  /// The pointer device a real user drags with on the running platform.
+  static PointerDeviceKind _defaultDragKind() =>
+      switch (defaultTargetPlatform) {
+        TargetPlatform.macOS ||
+        TargetPlatform.windows ||
+        TargetPlatform.linux => PointerDeviceKind.mouse,
+        _ => PointerDeviceKind.touch,
+      };
 
   /// Synthesize a mouse hover at the centre of the widget identified by
   /// [ref]. Drives `MouseRegion.onEnter`/`onExit` via the framework's
@@ -853,16 +872,30 @@ mixin GestureInteractionService {
     await _waitFrame();
   }
 
+  /// Dispatches a press-move-release sequence as [kind] pointer events.
+  ///
+  /// [kind] decides which recognizers compete for the gesture. Mouse wins a
+  /// drag-and-drop cleanly on desktop: scrollables don't track mouse drags
+  /// (default [ScrollBehavior.dragDevices] excludes the mouse), so the
+  /// target's pan recognizer takes the gesture uncontested — matching a
+  /// real user drag. Touch keeps scrollables in the arena, which a
+  /// swipe/fling relies on.
   static Future<void> _dispatchDrag(
     final ui.Offset from,
     final ui.Offset to, {
     final int steps = 10,
     final Duration perStep = const Duration(milliseconds: 16),
+    final PointerDeviceKind kind = PointerDeviceKind.touch,
   }) async {
     final binding = GestureBinding.instance;
     final pointer = _nextPointerId++;
     binding.handlePointerEvent(
-      PointerDownEvent(pointer: pointer, position: from, timeStamp: _now()),
+      PointerDownEvent(
+        pointer: pointer,
+        position: from,
+        kind: kind,
+        timeStamp: _now(),
+      ),
     );
 
     final dx = (to.dx - from.dx) / steps;
@@ -876,6 +909,7 @@ mixin GestureInteractionService {
           pointer: pointer,
           position: pos,
           delta: pos - last,
+          kind: kind,
           timeStamp: _now(),
         ),
       );
@@ -883,7 +917,12 @@ mixin GestureInteractionService {
     }
 
     binding.handlePointerEvent(
-      PointerUpEvent(pointer: pointer, position: to, timeStamp: _now()),
+      PointerUpEvent(
+        pointer: pointer,
+        position: to,
+        kind: kind,
+        timeStamp: _now(),
+      ),
     );
     await _waitFrame();
   }

--- a/mcp_toolkit/lib/src/toolkits/interaction_toolkit.dart
+++ b/mcp_toolkit/lib/src/toolkits/interaction_toolkit.dart
@@ -1,4 +1,5 @@
 import 'package:dart_mcp/client.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter_mcp_toolkit_core/flutter_mcp_toolkit_core.dart';
 import 'package:from_json_to_json/from_json_to_json.dart';
 import 'package:intentcall_core/intentcall_core.dart';
@@ -487,9 +488,15 @@ extension type OnDragEntry._(AgentCallEntry entry) implements AgentCallEntry {
             },
           );
         }
+        final kind = switch (parameters['kind']) {
+          'mouse' => PointerDeviceKind.mouse,
+          'touch' => PointerDeviceKind.touch,
+          _ => null,
+        };
         final result = await GestureInteractionService.drag(
           fromRef: fromRef,
           toRef: toRef,
+          kind: kind,
         );
         return MCPCallResult(
           message: result['success'] == true

--- a/packages/core/lib/src/commands/core_commands.dart
+++ b/packages/core/lib/src/commands/core_commands.dart
@@ -390,17 +390,29 @@ final class SwipeCommand extends CoreCommand {
 }
 
 /// Pointer device to synthesize for a [DragCommand].
+///
+/// Keeps command state typed; the wire protocol stays stringly. Values are
+/// parsed once via [parseDragPointerKind] and serialized back through
+/// [wireName] only at the extension-forwarding boundary.
 enum DragPointerKind {
+  /// Desktop-style pointer: scrollables ignore mouse drags, so the drag
+  /// reaches the target's drag/pan recognizer (drag-and-drop).
   mouse('mouse'),
+
+  /// Touch-style pointer: scrollables compete for the gesture, so a drag
+  /// over scrollable content scrolls it.
   touch('touch');
 
   const DragPointerKind(this.wireName);
 
+  /// String form used on the wire (tool schema enum and extension args).
   final String wireName;
 }
 
-/// Parses a wire value into a [DragPointerKind]. Null, empty and unknown
-/// values yield null — the app picks the platform default.
+/// Parses a wire [value] into a [DragPointerKind].
+///
+/// Returns null for null, empty and unknown values — the app then picks
+/// the platform default.
 DragPointerKind? parseDragPointerKind(final Object? value) {
   if (value == null) return null;
   final normalized = '$value'.trim().toLowerCase();

--- a/packages/core/lib/src/commands/core_commands.dart
+++ b/packages/core/lib/src/commands/core_commands.dart
@@ -389,6 +389,29 @@ final class SwipeCommand extends CoreCommand {
   String get name => 'swipe';
 }
 
+/// Pointer device to synthesize for a [DragCommand].
+enum DragPointerKind {
+  mouse('mouse'),
+  touch('touch');
+
+  const DragPointerKind(this.wireName);
+
+  final String wireName;
+}
+
+/// Parses a wire value into a [DragPointerKind]. Null, empty and unknown
+/// values yield null — the app picks the platform default.
+DragPointerKind? parseDragPointerKind(final Object? value) {
+  if (value == null) return null;
+  final normalized = '$value'.trim().toLowerCase();
+  for (final kind in DragPointerKind.values) {
+    if (kind.wireName == normalized) {
+      return kind;
+    }
+  }
+  return null;
+}
+
 final class DragCommand extends CoreCommand {
   const DragCommand({
     required this.fromRef,
@@ -401,9 +424,9 @@ final class DragCommand extends CoreCommand {
   final String toRef;
   final int? snapshotId;
 
-  /// Pointer device kind to synthesize (`mouse` | `touch`). Null lets the
-  /// app pick the platform default.
-  final String? kind;
+  /// Pointer device kind to synthesize. Null lets the app pick the
+  /// platform default.
+  final DragPointerKind? kind;
 
   @override
   String get name => 'drag';

--- a/packages/core/lib/src/commands/core_commands.dart
+++ b/packages/core/lib/src/commands/core_commands.dart
@@ -394,11 +394,16 @@ final class DragCommand extends CoreCommand {
     required this.fromRef,
     required this.toRef,
     this.snapshotId,
+    this.kind,
   });
 
   final String fromRef;
   final String toRef;
   final int? snapshotId;
+
+  /// Pointer device kind to synthesize (`mouse` | `touch`). Null lets the
+  /// app pick the platform default.
+  final String? kind;
 
   @override
   String get name => 'drag';

--- a/packages/core/lib/src/tools/interaction_input_schemas.dart
+++ b/packages/core/lib/src/tools/interaction_input_schemas.dart
@@ -237,6 +237,16 @@ Map<String, Object?> dragInputSchema() => <String, Object?>{
       'type': 'string',
       'description': 'Target widget ref.',
     },
+    'kind': <String, Object?>{
+      'type': 'string',
+      'enum': <String>['mouse', 'touch'],
+      'description':
+          'Pointer device to synthesize. Defaults to mouse on desktop '
+          'targets and touch elsewhere. Mouse keeps scrollables out of the '
+          'gesture arena, so the drag lands on the target\'s drag/pan '
+          'recognizer (drag-and-drop); touch keeps scrollables competing, '
+          'so a drag over scrollable content scrolls it instead.',
+    },
     'snapshotId': <String, Object?>{
       'type': 'integer',
       'description':

--- a/packages/server_capability_core/lib/src/tools/interaction_tools.dart
+++ b/packages/server_capability_core/lib/src/tools/interaction_tools.dart
@@ -161,7 +161,7 @@ void registerInteractionTools(final CapabilityContext context) {
         final fromRef = stringArgOrNull(args['fromRef']) ?? '';
         final toRef = stringArgOrNull(args['toRef']) ?? '';
         final snapshotId = intArgOrNull(args['snapshotId']);
-        final kind = stringArgOrNull(args['kind']);
+        final kind = parseDragPointerKind(args['kind']);
         return runCommand(
           runner,
           args,

--- a/packages/server_capability_core/lib/src/tools/interaction_tools.dart
+++ b/packages/server_capability_core/lib/src/tools/interaction_tools.dart
@@ -161,10 +161,16 @@ void registerInteractionTools(final CapabilityContext context) {
         final fromRef = stringArgOrNull(args['fromRef']) ?? '';
         final toRef = stringArgOrNull(args['toRef']) ?? '';
         final snapshotId = intArgOrNull(args['snapshotId']);
+        final kind = stringArgOrNull(args['kind']);
         return runCommand(
           runner,
           args,
-          DragCommand(fromRef: fromRef, toRef: toRef, snapshotId: snapshotId),
+          DragCommand(
+            fromRef: fromRef,
+            toRef: toRef,
+            snapshotId: snapshotId,
+            kind: kind,
+          ),
         );
       },
     ),


### PR DESCRIPTION
Fixes #116.

## What

`drag` dispatched its pointer sequence without an explicit `kind`, i.e. as touch. On desktop that hands the gesture to surrounding scrollables nearly every time: their directional recognizers accept at `kTouchSlop` (18 px along the axis) while the target's pan recognizer needs `kPanSlop` (36 px global) — so dragging a card over a scrollable board scrolls the board. A real desktop user never hits this because scrollables don't track mouse drags (default `ScrollBehavior.dragDevices` excludes the mouse); `tap`/`long_press`/`hover` in the same service already synthesize mouse for exactly that reason.

## How

- `_dispatchDrag` takes a `kind` parameter (touch remains the default for the internal helper).
- `GestureInteractionService.drag` resolves the kind by `defaultTargetPlatform`: mouse on macOS/Windows/Linux, touch elsewhere — the device a real user would drag with there. The effective kind is reported in the result payload.
- Optional `kind` (`mouse` | `touch`) exposed end-to-end for callers that need the other behavior: shared `dragInputSchema()`, `DragCommand`, server forwarding (`command_executor`, `commands_catalog`, `interaction_tools`), and the app-side dynamic tool handler.
- `swipe` keeps touch unconditionally — a fling relies on scrollables staying in the arena.

## Testing

- `mcp_toolkit/test/interaction_toolkit_schema_parity_test.dart` — green.
- `packages/server_capability_core/test/tools/interaction_input_schemas_test.dart` — green.
- Live on macOS (kanban card in a vertical list inside a horizontal board scroller): before — 5 of 6 drags scrolled the board; after — the drop handler fires reliably, scroll no longer steals the gesture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag interactions now support selecting a pointer device type: mouse or touch.
  * The default device is selected automatically based on the platform.
  * Drag results now report the device type used.
  * Invalid or omitted device values continue using the platform default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->