### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ More detail: [docs/contributing/contributors.mdx](docs/contributing/contributors
 
 ## Star History
 
-<a href="https://www.star-history.com/?type=date&repos=Arenukvern%2Fmcp_flutter">
+<a href="https://star-history.dera.page/#Arenukvern/mcp_flutter&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=Arenukvern/mcp_flutter&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=Arenukvern/mcp_flutter&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=Arenukvern/mcp_flutter&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Arenukvern/mcp_flutter&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Arenukvern/mcp_flutter&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Arenukvern/mcp_flutter&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in our README has been broken and is in need of a fix. This change updates the chart to point to the current service so it renders correctly again, restoring the visual history of the project for visitors and contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the current `star-history.dera.page` URLs.
  * Replaced legacy Star History page and chart endpoints in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->